### PR TITLE
Basic panels setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "keywords": [
     "microservices"
   ],
-  "author": "Joe Pavlisko, Conor Sexton, Joel Riviera, Donald Blanc",
+  "author": "Joe Pavlisko, Conor Sexton, Joel Rivera, Donald Blanc",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/jdcj-oslabs/apimocking/issues"

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <h1>Undefined ;)</h1>
-  <div id="app"></div>
+  <main id="app"></main>
 </body>
 <script type="text/javascript" src="../dist/bundle.js"></script>
 </html>

--- a/src/main/containers/DestinationPanel.jsx
+++ b/src/main/containers/DestinationPanel.jsx
@@ -1,0 +1,14 @@
+import React, { useState } from 'react';
+
+const DestinationPanel = () => {
+  const [isLoading, setLoading] = useState(false);
+  const [data, setData] = useState({});
+
+  return (
+    <section className='panel'>
+    <p>Data destination panel</p>
+    </section>
+  )
+};
+
+export default DestinationPanel;

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import SourcePanel from './SourcePanel.jsx';
+import TestPanel from './TestPanel.jsx';
+import DestinationPanel from './DestinationPanel.jsx';
+
+const Panels = () => {
+  const [activePanel, setActivePanel] = useState('source');
+
+  return (
+    <section>
+      <SourcePanel/>
+      <TestPanel/>
+      <DestinationPanel/>
+    </section>
+  );
+};
+
+export default Panels;

--- a/src/main/containers/SourcePanel.jsx
+++ b/src/main/containers/SourcePanel.jsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+
+const SourcePanel = () => {
+  const [isLoading, setLoading] = useState(false);
+  const [data, setData] = useState({});
+
+  return (
+    <section className='panel'>
+    <p>Data source panel</p>
+      {/* 
+        Request bar
+        Data canvas
+      */}
+    </section>
+  )
+};
+
+export default SourcePanel;

--- a/src/main/containers/TestPanel.jsx
+++ b/src/main/containers/TestPanel.jsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+
+const TestPanel = (props) => {
+  const [mockups, setData] = useState([props.data]);
+
+  return (
+    <section className='panel'>
+      <p>Test panel</p>
+    </section>
+  )
+};
+
+export default TestPanel;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import Panels from './containers/Panels.jsx';
 
 const App = () => (
    <div>
       <h1>Hello world!! From REACT SIDE</h1>
       <h2>Welcome MIME team</h2>
+      <Panels/>
    </div>
 );
 ReactDOM.render(<App/>, document.getElementById('app'));


### PR DESCRIPTION
Sets up basic app structure with main container wrapper and three panels.

### Overview
- Adds `components` and `containers` directories to `src/main`
- Panels is the top-level container and for now, renders three sub-panels: `Source`, `Test`, and `Destination`
- Each sub-panel is barebones for now—just proof-of-concept to make sure we can get three of them to render on the screen. Will build out Hooks and sub-components in a future PR.