### PR TITLE
Display read-only data in source and test panels

### DIFF
--- a/src/main/components/DataTree.jsx
+++ b/src/main/components/DataTree.jsx
@@ -4,7 +4,8 @@ import JsonTree from '../lib/treeView/jsonTree';
 import '../lib/treeView/jsonTree.css';
 
 const DataTree = (props) => {
-  const { treeCount, data } = props;
+  const { treeCount, data, options } = props;
+  const { onAdd, onEdit, onDelete, enableClipboard } = options;
 
   const renderTree = (htmlElement) => {
     const tree = JsonTree.create(data, htmlElement);
@@ -16,14 +17,20 @@ const DataTree = (props) => {
 
   useEffect(() => {
     const test = document.getElementById(`tree-${treeCount}`);
-    // renderTree(test);
   });
 
   return (
     <section className='wrapper' id={`tree-${treeCount}`} style= {{ maxHeight: '350px', overflow: 'auto' }} >
       {/* Tree gets rendered here after component mounts */}
-      <ReactJson src={data} theme='bright:inverted' iconStyle='square'
-        onEdit={changeObject} onAdd={changeObject} onDelete={changeObject}/>
+      <ReactJson 
+        src={data} 
+        theme='bright:inverted'
+        iconStyle='square'
+        onAdd={onAdd}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        enableClipboard={enableClipboard}
+        />
     </section>
   );
 };

--- a/src/main/components/DataTree.jsx
+++ b/src/main/components/DataTree.jsx
@@ -21,7 +21,7 @@ const DataTree = (props) => {
     <section className='wrapper' id={`tree-${treeCount}`} style= {{ maxHeight: '350px', overflow: 'auto' }} >
       {/* Tree gets rendered here after component mounts */}
       <ReactJson
-        src={data} 
+        src={data}
         theme='bright:inverted'
         iconStyle='square'
         onAdd={onAdd}

--- a/src/main/components/DataTree.jsx
+++ b/src/main/components/DataTree.jsx
@@ -5,7 +5,9 @@ import '../lib/treeView/jsonTree.css';
 
 const DataTree = (props) => {
   const { treeCount, data, options } = props;
-  const { onAdd, onEdit, onDelete, enableClipboard } = options;
+  const {
+    onAdd, onEdit, onDelete, enableClipboard,
+  } = options;
 
   const renderTree = (htmlElement) => {
     const tree = JsonTree.create(data, htmlElement);
@@ -15,14 +17,10 @@ const DataTree = (props) => {
     console.log(val);
   };
 
-  useEffect(() => {
-    const test = document.getElementById(`tree-${treeCount}`);
-  });
-
   return (
     <section className='wrapper' id={`tree-${treeCount}`} style= {{ maxHeight: '350px', overflow: 'auto' }} >
       {/* Tree gets rendered here after component mounts */}
-      <ReactJson 
+      <ReactJson
         src={data} 
         theme='bright:inverted'
         iconStyle='square'

--- a/src/main/containers/DataCanvas.jsx
+++ b/src/main/containers/DataCanvas.jsx
@@ -3,7 +3,9 @@ import Button from '../components/Button.jsx';
 import DataTree from '../components/DataTree.jsx';
 
 const DataCanvas = (props) => {
-  const { data, treeCount, updateTreeCount, options } = props;
+  const {
+    data, treeCount, updateTreeCount, options,
+  } = props;
   // const { onAdd, onEdit, onDelete, enableClipboard } = options;
   // Display empty state for no data
   if (!data) {
@@ -18,7 +20,7 @@ const DataCanvas = (props) => {
   // Increment tree count and render data
   if (!treeCount) updateTreeCount(1);
   return (
-    <DataTree 
+    <DataTree
       treeCount={treeCount}
       data={data}
       options={options}

--- a/src/main/containers/DataCanvas.jsx
+++ b/src/main/containers/DataCanvas.jsx
@@ -3,7 +3,8 @@ import Button from '../components/Button.jsx';
 import DataTree from '../components/DataTree.jsx';
 
 const DataCanvas = (props) => {
-  const { data, treeCount, updateTreeCount } = props;
+  const { data, treeCount, updateTreeCount, options } = props;
+  // const { onAdd, onEdit, onDelete, enableClipboard } = options;
   // Display empty state for no data
   if (!data) {
     return (
@@ -15,9 +16,13 @@ const DataCanvas = (props) => {
     );
   }
   // Increment tree count and render data
-  if (!treeCount) updateTreeCount(treeCount + 1);
+  if (!treeCount) updateTreeCount(1);
   return (
-    <DataTree treeCount={treeCount} data={data}/>
+    <DataTree 
+      treeCount={treeCount}
+      data={data}
+      options={options}
+    />
   );
 };
 

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import SourcePanel from './SourcePanel.jsx';
 import TestPanel from './TestPanel.jsx';
 import DestinationPanel from './DestinationPanel.jsx';
+import { smallData } from '../dummyData';
 
 const Panels = () => {
   const [activePanel, setActivePanel] = useState('source');
-  const [dataTreeCount, setDataTreeCount] = useState(0);
+  const [treeCount, setDataTreeCount] = useState(0);
   const [data, setData] = useState(undefined);
   // Tests are objects with
   // { payload: JSON that represents test,
@@ -28,16 +29,16 @@ const Panels = () => {
       status: '',
     }],
   );
-
   return (
     <section>
-      <SourcePanel treeCount={dataTreeCount}
+      <SourcePanel treeCount={treeCount}
                    updateTreeCount={setDataTreeCount}
                    data={data}
                    setData={setData}/>
-      <TestPanel treeCount={dataTreeCount}
+      <TestPanel treeCount={treeCount}
                  updateTreeCount={setDataTreeCount}
-                 setData={setData} />
+                 setData={setData}
+                 data={data} />
       <DestinationPanel tests={tests} setTests={setTests} />
     </section>
   );

--- a/src/main/containers/SourcePanel.jsx
+++ b/src/main/containers/SourcePanel.jsx
@@ -1,18 +1,29 @@
 import React, { useState } from 'react';
 import DataCanvas from './DataCanvas.jsx';
 import RequestBar from '../components/RequestBar.jsx';
-import { smallData } from '../dummyData';
 
 const SourcePanel = (props) => {
   const {
     treeCount, updateTreeCount, data, setData,
   } = props;
+  
+  const dataTreeOptions = {
+    onAdd: false,
+    onEdit: false,
+    onDelete: false,
+    enableClipboard: false,
+  };
 
   return (
     <section className='panel'>
       <h1>Data source panel</h1>
       <RequestBar SourceOrDest='source' setData={setData}/>
-      <DataCanvas treeCount={treeCount} updateTreeCount={updateTreeCount} data={data}/>
+      <DataCanvas 
+        treeCount={treeCount} 
+        updateTreeCount={updateTreeCount} 
+        data={data}
+        options={dataTreeOptions}
+      />
     </section>
   );
 };

--- a/src/main/containers/TestPanel.jsx
+++ b/src/main/containers/TestPanel.jsx
@@ -2,16 +2,28 @@ import React, { useState } from 'react';
 import DataTree from '../components/DataTree.jsx';
 // sample JSON to pass down as props. Will be able to remove as the project evolves.
 import { largeData, smallData } from '../dummyData';
+import DataCanvas from './DataCanvas.jsx';
 
 // will need to get data from the get request to pass to the formatted view
 
 const TestPanel = (props) => {
+  const { data, updateTreeCount } = props;
   const [mockups, setData] = useState([props.data]);
+  const dataTreeOptions = {
+    onAdd: false,
+    onEdit: false,
+    onDelete: false,
+    enableClipboard: false,
+  };
 
   return (
     <section className='panel' >
       <p>Test panel</p>
-      {/* <DataTree data={largeData}/> */}
+      <DataCanvas 
+        data={data} 
+        updateTreeCount={updateTreeCount} 
+        options={dataTreeOptions}
+      />
     </section>
   );
 };


### PR DESCRIPTION
This is a fairly small PR that does one main thing:
Sets up structure to pass `options` props from panels down to data tree so we can enable/disable editing, adding, etc.