### PR TITLE
Set up basic panel layout

### DIFF
--- a/src/main/containers/DestinationPanel.jsx
+++ b/src/main/containers/DestinationPanel.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import RequestBar from '../components/RequestBar.jsx';
 import ResponseComponent from '../components/ResponseComponent.jsx';
+import StyledPanel from './StyledPanel.jsx';
 
 const DestinationPanel = (props) => {
   const { tests, setTests } = props;
@@ -20,7 +21,7 @@ const DestinationPanel = (props) => {
   }
 
   return (
-    <section className='panel'>
+    <StyledPanel>
       <p> Data destination panel </p>
       <RequestBar
         SourceOrDest='dest'
@@ -29,7 +30,7 @@ const DestinationPanel = (props) => {
       />
 
       {responseComponentsList}
-    </section>
+    </StyledPanel>
   );
 };
 

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -2,12 +2,17 @@ import React, { useState } from 'react';
 import SourcePanel from './SourcePanel.jsx';
 import TestPanel from './TestPanel.jsx';
 import DestinationPanel from './DestinationPanel.jsx';
+import styled from 'styled-components';
 import { smallData } from '../dummyData';
 
 const Panels = () => {
   const [activePanel, setActivePanel] = useState('source');
   const [treeCount, setDataTreeCount] = useState(0);
   const [data, setData] = useState(undefined);
+
+  const PanelsWrapper = styled.section`
+    display: flex;
+  `;
   // Tests are objects with
   // { payload: JSON that represents test,
   //   status: initial value of '' };
@@ -30,7 +35,7 @@ const Panels = () => {
     }],
   );
   return (
-    <section>
+    <PanelsWrapper>
       <SourcePanel treeCount={treeCount}
                    updateTreeCount={setDataTreeCount}
                    data={data}
@@ -40,7 +45,7 @@ const Panels = () => {
                  setData={setData}
                  data={data} />
       <DestinationPanel tests={tests} setTests={setTests} />
-    </section>
+    </PanelsWrapper>
   );
 };
 

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import SourcePanel from './SourcePanel.jsx';
 import TestPanel from './TestPanel.jsx';
 import DestinationPanel from './DestinationPanel.jsx';
-import styled from 'styled-components';
 import { smallData } from '../dummyData';
 
 const Panels = () => {

--- a/src/main/containers/SourcePanel.jsx
+++ b/src/main/containers/SourcePanel.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import DataCanvas from './DataCanvas.jsx';
 import RequestBar from '../components/RequestBar.jsx';
+import StyledPanel from './StyledPanel.jsx';
 
 const SourcePanel = (props) => {
   const {
@@ -15,7 +16,7 @@ const SourcePanel = (props) => {
   };
 
   return (
-    <section className='panel'>
+    <StyledPanel>
       <h1>Data source panel</h1>
       <RequestBar SourceOrDest='source' setData={setData}/>
       <DataCanvas 
@@ -24,7 +25,7 @@ const SourcePanel = (props) => {
         data={data}
         options={dataTreeOptions}
       />
-    </section>
+    </StyledPanel>
   );
 };
 

--- a/src/main/containers/StyledPanel.jsx
+++ b/src/main/containers/StyledPanel.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledPanel = styled.section`
+  border: 1px solid paleturquoise;
+  padding: 1em 2em;
+  width: 33.3333vw;
+  // width: ${props => (props.active ? '80vw' : '10vw')};
+`;
+
+export default StyledPanel;

--- a/src/main/containers/TestPanel.jsx
+++ b/src/main/containers/TestPanel.jsx
@@ -3,6 +3,7 @@ import DataTree from '../components/DataTree.jsx';
 // sample JSON to pass down as props. Will be able to remove as the project evolves.
 import { largeData, smallData } from '../dummyData';
 import DataCanvas from './DataCanvas.jsx';
+import StyledPanel from './StyledPanel.jsx';
 
 // will need to get data from the get request to pass to the formatted view
 
@@ -17,14 +18,14 @@ const TestPanel = (props) => {
   };
 
   return (
-    <section className='panel' >
+    <StyledPanel>
       <p>Test panel</p>
       <DataCanvas 
         data={data} 
         updateTreeCount={updateTreeCount} 
         options={dataTreeOptions}
       />
-    </section>
+    </StyledPanel>
   );
 };
 


### PR DESCRIPTION
## Overview
This lays a very basic foundation for our collapsible panel UI—here’s what’s changed:

- The top-level `Panels` now uses a styled `PanelsWrapper` component that sets `display: flex` for a horizontal layout
- Each of the main three panels uses a `StyledPanel` wrapper instead of a standard `<section class="panel">` element
- The `StyledPanel` wrapper adds a light blue border and sets an initial width of 33% of the viewport
- There’s commented out code in `StyledPanel` to allow for setting the width based on an `active` prop boolean (e.g. if the active prop is `true`, the panel will expand, and if `false`, it will collapse)