### PR TITLE
Mouseover and Dest Panel display adjustments (changeonly)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,6 @@
   <title>MIME</title>
 </head>
 <body>
-  <h1>Undefined ;)</h1>
   <main id="app"></main>
 </body>
 </html>

--- a/src/main/components/DataTree.jsx
+++ b/src/main/components/DataTree.jsx
@@ -10,7 +10,8 @@ const DataTree = (props) => {
   } = options;
 
   const changeObject = (src) => {
-    saveUpdatedTree(src.updated_src, treeCount);
+    console.log('source', src);
+    saveUpdatedTree(src.updated_src, treeCount, src.new_value, src.name, src.namespace);
   };
 
   return (

--- a/src/main/components/InlineInput.jsx
+++ b/src/main/components/InlineInput.jsx
@@ -8,6 +8,7 @@ const InlineInput = styled.input`
   font-size: 1em;
   line-height: 1em;
   padding: 0.825em;
+  width: 100%;
   &:focus {
     outline: none;
   }

--- a/src/main/containers/App.jsx
+++ b/src/main/containers/App.jsx
@@ -4,8 +4,7 @@ import Panels from './Panels.jsx';
 
 const App = () => (
    <div>
-      <h1>Hello world!! From REACT SIDE</h1>
-      <h2>Welcome MIME team</h2>
+      <h1>An Open-Source API Data Mocking Tool</h1>
       <Panels/>
    </div>
 );

--- a/src/main/containers/DestinationPanel.jsx
+++ b/src/main/containers/DestinationPanel.jsx
@@ -4,14 +4,14 @@ import ResponseComponent from '../components/ResponseComponent.jsx';
 import StyledPanel from './StyledPanel.jsx';
 
 const DestinationPanel = (props) => {
-  const { tests, setTests, active, onClickFunction } = props;
+  const { tests, setTests, active, onClickFunction, testsDiff } = props;
 
   const responseComponentsList = [];
   for (let i = 0; i < tests.length; i += 1) {
     responseComponentsList.push(
       <ResponseComponent
         status={tests[i].status}
-        payload={tests[i].payload}
+        payload={testsDiff[i]}
 
         // fix later
         key={`DestPanelTest ${i}`}
@@ -21,7 +21,7 @@ const DestinationPanel = (props) => {
 
   if (active) {
     return (
-      <StyledPanel active={active}>
+      <StyledPanel active={active} onMouseOver={() => setCursor('default')}>
         <h1>Data destination panel</h1>
         <RequestBar
           SourceOrDest='dest'

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -10,14 +10,16 @@ const Panels = () => {
   const [activePanel, setActivePanel] = useState('source');
   const [treeCount, setTreeCount] = useState(0);
   const [data, setData] = useState(undefined);
+  const [tests, setTests] = useState([]);
+  const [cursor, setCursor] = useState('default');
 
   const PanelsWrapper = styled.section`
     display: flex;
+    cursor: ${cursor};
   `;
   // Tests are objects with
   // { payload: JSON that represents test,
   //   status: initial value of '' };
-  const [tests, setTests] = useState([]);
 
   return (
     <PanelsWrapper>
@@ -28,7 +30,9 @@ const Panels = () => {
         data={data}
         setData={setData}
         setTests={setTests}
-        active={(activePanel === 'source')} />
+        active={(activePanel === 'source')}
+        setCursor={setCursor} />
+
       <TestPanel 
         onClickFunction={() => setActivePanel('test')}
         treeCount={treeCount}
@@ -36,12 +40,16 @@ const Panels = () => {
         data={data}
         setTests={setTests}
         tests={tests}
-        active={(activePanel === 'test')} />
+        active={(activePanel === 'test')}
+        setCursor={setCursor} />
+
       <DestinationPanel 
         onClickFunction={() => setActivePanel('dest')}
         tests={tests}
         setTests={setTests}
-        active={(activePanel === 'dest')} />
+        active={(activePanel === 'dest')}
+        setCursor={setCursor} />
+
     </PanelsWrapper>
   );
 };

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -11,6 +11,7 @@ const Panels = () => {
   const [treeCount, setTreeCount] = useState(0);
   const [data, setData] = useState(undefined);
   const [tests, setTests] = useState([]);
+  const [testsDiff, setTestsDiff] = useState([ {} ]);
   const [cursor, setCursor] = useState('default');
 
   const PanelsWrapper = styled.section`
@@ -41,14 +42,17 @@ const Panels = () => {
         setTests={setTests}
         tests={tests}
         active={(activePanel === 'test')}
-        setCursor={setCursor} />
+        setCursor={setCursor}
+        testsDiff={testsDiff}
+        setTestsDiff={setTestsDiff} />
 
       <DestinationPanel 
         onClickFunction={() => setActivePanel('dest')}
         tests={tests}
         setTests={setTests}
         active={(activePanel === 'dest')}
-        setCursor={setCursor} />
+        setCursor={setCursor}
+        testsDiff={testsDiff} />
 
     </PanelsWrapper>
   );

--- a/src/main/containers/SourcePanel.jsx
+++ b/src/main/containers/SourcePanel.jsx
@@ -5,7 +5,7 @@ import StyledPanel from './StyledPanel.jsx';
 
 const SourcePanel = (props) => {
   const {
-    treeCount, updateTreeCount, data, setData, setTests, active, onClickFunction
+    treeCount, updateTreeCount, data, setData, setTests, active, onClickFunction, setCursor
   } = props;
 
   const dataTreeOptions = {
@@ -17,7 +17,7 @@ const SourcePanel = (props) => {
 
   if (active) {
     return (
-      <StyledPanel active={active}>
+      <StyledPanel active={active} onMouseOver={() => setCursor('default')}>
         <h1>Data source panel</h1>
         <RequestBar SourceOrDest='source' setData={setData} setTests={setTests} />
         <DataCanvas

--- a/src/main/containers/SourcePanel.jsx
+++ b/src/main/containers/SourcePanel.jsx
@@ -31,7 +31,11 @@ const SourcePanel = (props) => {
   }
 
   return (
-    <StyledPanel onClick={onClickFunction} active={active}>
+    <StyledPanel
+      onClick={onClickFunction}
+      active={active}
+      onMouseOver={() => setCursor('pointer')} 
+    >
       <h1>Data source panel</h1>
     </StyledPanel>
   );

--- a/src/main/containers/TestPanel.jsx
+++ b/src/main/containers/TestPanel.jsx
@@ -60,6 +60,7 @@ const TestPanel = (props) => {
     // the ID of the test will be the same as the position in the array
     setTestsListCounter(testsListCounter + 1);
     setTests(testsClone);
+    setTestsDiff(testsDiffClone);
   }
 
   if (active) {

--- a/src/main/containers/TestPanel.jsx
+++ b/src/main/containers/TestPanel.jsx
@@ -9,7 +9,7 @@ import StyledPanel from './StyledPanel.jsx';
 
 const TestPanel = (props) => {
   const {
-    tests, active, treeCount, updateTreeCount, data, setTests, onClickFunction
+    tests, active, treeCount, updateTreeCount, data, setTests, onClickFunction, setTestsDiff, testsDiff, setCursor
   } = props;
   const [testsListCounter, setTestsListCounter] = useState(0);
   const dataTreeOptions = {
@@ -19,42 +19,52 @@ const TestPanel = (props) => {
     enableClipboard: false,
   };
   
-  
-  function saveUpdatedTree(newData, arrayPosition) {
+  function saveUpdatedTree(newData, arrayPosition, newValue, name, namespace) {
     const testsClone = [...tests];
+    const testsDiffClone = [...testsDiff];
     testsClone[arrayPosition].payload = newData;
+    console.log('testsDiffClone', testsDiffClone);
+    console.log('testsDiffClone[arrayPosition]', testsDiffClone[arrayPosition]);
+
+    if (!testsDiffClone[arrayPosition][namespace]) {
+      testsDiffClone[arrayPosition][namespace] = {};
+    }
+    testsDiffClone[arrayPosition][namespace][name] = newValue;
+
     setTests(testsClone);
+    setTestsDiff(testsDiffClone);
   }
-    
+
   const testsList = [];
   let i = 0;
   tests.forEach((test) => {
 
     testsList.push(
       <DataTree
-          treeCount={i}
-          key={`TestPanelDataTree ${i}`}
-          data={test.payload}
-          options={dataTreeOptions}
-          saveUpdatedTree={saveUpdatedTree}
+        treeCount={i}
+        key={`TestPanelDataTree ${i}`}
+        data={test.payload}
+        options={dataTreeOptions}
+        saveUpdatedTree={saveUpdatedTree}
       />,
     );
     i += 1;
   });
 
   function createNewTest() {
-  const testsClone = [...tests];
+    const testsClone = [...tests];
+    const testsDiffClone = [...testsDiff];
     testsClone.push({ payload: data, status: '' });
+    testsDiffClone.push({});
   
-  // the ID of the test will be the same as the position in the array
-  setTestsListCounter(testsListCounter + 1);
-  setTests(testsClone);
+    // the ID of the test will be the same as the position in the array
+    setTestsListCounter(testsListCounter + 1);
+    setTests(testsClone);
   }
 
   if (active) {
     return (
-      
-        <StyledPanel active={active}>
+        <StyledPanel active={active} onMouseOver={() => setCursor('default')}>
           <h1>Test panel</h1>
           <div>
             <p>Server Response:</p>

--- a/src/main/containers/TestPanel.jsx
+++ b/src/main/containers/TestPanel.jsx
@@ -68,17 +68,17 @@ const TestPanel = (props) => {
           
           {testsList}
         </StyledPanel>
-      
-
     )
   }
 
   return (
-    <StyledPanel onClick={onClickFunction} active={active}>
-      <h1>Test panel</h1>
+    <StyledPanel
+      onClick={onClickFunction}
+      active={active}
+      onMouseOver={() => setCursor('pointer')} >
+        <h1>Test panel</h1>
     </StyledPanel>
   )
-
 };
 
 export default TestPanel;


### PR DESCRIPTION
- On mouseover of collapsed panels, the cursor will change to indicate clicking is possible
- Data destination input box now only displays the changes that have been made!
- We can have this for both the first and all additional tests
- Conor, make sure you note how the data is displayed for ADD, EDIT, & DELETE functionalities!