### PR TITLE
Named mockups

### DIFF
--- a/src/main/components/DataTree.jsx
+++ b/src/main/components/DataTree.jsx
@@ -31,7 +31,7 @@ const DataTree = (props) => {
         theme='chalk'
         iconStyle='circle'
         style={styles}
-        collapsed={2}
+        collapsed={0}
         onAdd={(onAdd) ? changeObject : false}
         onEdit={(onEdit) ? changeObject : false}
         onDelete={(onDelete) ? changeObject : false}

--- a/src/main/components/Mockup.jsx
+++ b/src/main/components/Mockup.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import NameForm from './NameForm.jsx';
+import MockupName from './MockupName.jsx';
+import DataTree from './DataTree.jsx';
+
+const dataTreeOptions = {
+  onAdd: true,
+  onEdit: true,
+  onDelete: true,
+  enableClipboard: false,
+};
+
+const Mockup = (props) => {
+  const { test, index } = props;
+
+  // State
+  const [name, setName] = useState(test.name);
+
+  // Mode controls display of name vs. name edit form, and is set by child compoments
+  const [mode, setMode] = useState('view');
+
+  return (
+    <article className="mockup" key={`mockup-${index}`}>
+      {mode === 'view'
+        ? <MockupName name={name || `Test #${index + 1}`} setMode={setMode} />
+        : <NameForm name={name} index={index} setMode={setMode} setName={setName} />
+      }
+      <DataTree
+          treeId={index}
+          data={test.payload}
+          name={name}
+          options={dataTreeOptions}
+        />
+    </article>
+  );
+};
+
+export default Mockup;

--- a/src/main/components/Mockup.jsx
+++ b/src/main/components/Mockup.jsx
@@ -11,7 +11,7 @@ const dataTreeOptions = {
 };
 
 const Mockup = (props) => {
-  const { test, index } = props;
+  const { test, index, saveUpdatedTree } = props;
 
   // State
   const [name, setName] = useState(test.name);
@@ -30,6 +30,7 @@ const Mockup = (props) => {
           data={test.payload}
           name={name}
           options={dataTreeOptions}
+          saveUpdatedTree={saveUpdatedTree}
         />
     </article>
   );

--- a/src/main/components/MockupName.jsx
+++ b/src/main/components/MockupName.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useContext } from 'react';
+import styled from 'styled-components';
+
+// Styles
+const Header = styled.header`
+  display: flex;
+  align-items: flex-end;
+  h3 {
+    margin-bottom: 0;
+  }
+`;
+
+const Name = styled.h3`
+  font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  color: #292F32;
+`;
+
+const EditButton = styled.button`
+  background: none;
+  border: none;
+  color: #4299EA;
+  font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  letter-spacing: 0.05em;
+  margin: 0 auto 0.25em 0.825em;
+  text-transform: uppercase;
+  opacity: ${props => (props.hovered ? 1 : 0)};
+  transition: all 0.2s ease-in-out;
+  &:hover { cursor: pointer; }
+  &:active, &:focus {
+    color: #1F4E7A;
+    outline: 0;
+  }
+`;
+
+const MockupName = (props) => {
+  const { name, setMode } = props;
+  // Hovered state is passed to edit button to control visibility
+  const [hovered, setHovered] = useState(false);
+
+
+  return (
+    <Header onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+      <Name>{name}</Name>
+      <EditButton onClick={() => { setMode('edit'); }} hovered={hovered}>
+      Edit
+      </EditButton>
+    </Header>
+  );
+};
+
+export default MockupName;

--- a/src/main/components/NameForm.jsx
+++ b/src/main/components/NameForm.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useContext } from 'react';
+import styled from 'styled-components';
+import { TestsContext } from '../testsContext';
+import InlineForm from './InlineForm.jsx';
+import InlineInput from './InlineInput.jsx';
+
+// Form styles
+const Form = styled(InlineForm)`
+  flex-direction: column;
+  align-items: flex-start;
+  margin: 1em auto;
+`;
+
+const Input = styled(InlineInput)`
+  padding: 0;
+  padding-bottom: 0.25em;
+`;
+
+const Label = styled.label`
+  color:  #BCC1C2;
+  font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-size: 0.75em;
+`;
+
+const NameForm = (props) => {
+  const {
+    name, index, setMode, setName,
+  } = props;
+
+  // State
+  const [tests, setTests] = useContext(TestsContext);
+  const [newName, setNewName] = useState('');
+
+  // Event handlers
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const testsCopy = [...tests];
+    testsCopy[index].name = newName;
+
+    // Update name in test array, then set mockup “mode” to trigger re-render
+    setName(newName);
+    setTests(testsCopy);
+    setMode('view');
+  };
+
+  const updateName = (event) => {
+    const { value } = event.target;
+    setNewName(value);
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Input
+        name="name"
+        type="text"
+        placeholder={ name || `Test #${index + 1}`}
+        onChange={updateName}
+      >
+      </Input>
+      <Label htmlFor="name">Name</Label>
+    </Form>
+  );
+};
+
+export default NameForm;

--- a/src/main/components/ResponseComponent.jsx
+++ b/src/main/components/ResponseComponent.jsx
@@ -45,7 +45,7 @@ const Header = styled.header`
 
 const ResponseComponent = (props) => {
   const {
-    status, payload, name,
+    status, payload, name, index
   } = props;
 
   /* Download SF Symbols to view icons
@@ -59,7 +59,7 @@ const ResponseComponent = (props) => {
   return (
     <ResponseWrapper>
       <Header>
-        <h3>{ name || 'Untitled test' }</h3>
+        <h3>{ name || `Test #${index + 1}` }</h3>
         <Icon status={status}>{checkmark}</Icon>
         { status || 'Ready to send' }
       </Header>

--- a/src/main/components/ResponseComponent.jsx
+++ b/src/main/components/ResponseComponent.jsx
@@ -1,27 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import DataTree from './DataTree.jsx';
 
 const ResponseWrapper = styled.article`
   background-color: #F0F3F4;
   border-radius: 3px;
-  box-shadow: inset 
-  box-shadow: inset 0 0 1px 0 rgba(41,47,50,0.25);
+  box-shadow: inset;
+  box-shadow: inset 0 0 1px 0 rgba(41, 47, 50, 0.25);
   display: flex;
   justify-content: space-between;
-  align-items: center;
   padding: 1em;
   margin-bottom: 1em;
 `;
 
 const Icon = styled.span`
   font-family: 'SF Pro Text';
-  margin-right: 1em;
+  margin-right: 0.625em;
   color: ${(props) => {
     if (props.status >= 200 && props.status < 300) return '#77B86B;';
     if (props.status >= 300) return '#E5544C;';
     return '#292F32;';
-  }}
+  }};
 `;
 
 const Code = styled.textarea`
@@ -38,13 +36,21 @@ const Code = styled.textarea`
 
 const Header = styled.header`
   font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  h3 {
+    color: #292F32;
+    margin: 0;
+    padding-bottom: 0.5em;
+  }
 `;
 
 const ResponseComponent = (props) => {
   const {
-    status, payload,
+    status, payload, name,
   } = props;
 
+  /* Download SF Symbols to view icons
+  (https://developer.apple.com/design/human-interface-guidelines/sf-symbols/)
+  (SVG icons to come) */
   let checkmark = '􀍡';
   if (status >= 200 && status < 300) {
     checkmark = '􀁣';
@@ -53,8 +59,9 @@ const ResponseComponent = (props) => {
   return (
     <ResponseWrapper>
       <Header>
+        <h3>{ name || 'Untitled test' }</h3>
         <Icon status={status}>{checkmark}</Icon>
-        {status || 'Ready to Send'}
+        { status || 'Ready to send' }
       </Header>
       <Code
         cols='50'

--- a/src/main/containers/DestinationPanel.jsx
+++ b/src/main/containers/DestinationPanel.jsx
@@ -18,6 +18,7 @@ const DestinationPanel = (props) => {
         status={tests[i].status}
         payload={testsDiff[i]}
         name={tests[i].name}
+        index={i}
         // fix later
         key={`DestPanelTest ${i}`}
       />,

--- a/src/main/containers/DestinationPanel.jsx
+++ b/src/main/containers/DestinationPanel.jsx
@@ -17,7 +17,7 @@ const DestinationPanel = (props) => {
       <ResponseComponent
         status={tests[i].status}
         payload={testsDiff[i]}
-
+        name={tests[i].name}
         // fix later
         key={`DestPanelTest ${i}`}
       />,

--- a/src/main/containers/DestinationPanel.jsx
+++ b/src/main/containers/DestinationPanel.jsx
@@ -7,7 +7,7 @@ import PerformanceMetrics from '../components/PerformanceMetrics.jsx';
 
 const DestinationPanel = (props) => {
   const {
-    active, onClickFunction, testsDiff, setCursor, fetchTimes, setFetchTimes,
+    active, onClickFunction, testsDiff, fetchTimes, setFetchTimes,
   } = props;
   const [tests, setTests] = useContext(TestsContext);
 
@@ -28,7 +28,7 @@ const DestinationPanel = (props) => {
 
   if (active) {
     return (
-      <StyledPanel active={active} onMouseOver={() => setCursor('default')}>
+      <StyledPanel active={active} style={{cursor: 'default'}}>
         <RequestBar
           SourceOrDest='dest'
           fetchTimes={fetchTimes}
@@ -44,7 +44,7 @@ const DestinationPanel = (props) => {
 
   // only returned if not active
   return (
-    <StyledPanel onClick={onClickFunction} active={active}>
+    <StyledPanel onClick={onClickFunction} active={active} style={{cursor: 'pointer'}}>
       <h1>Destination</h1>
     </StyledPanel>
   );

--- a/src/main/containers/MockupsPanel.jsx
+++ b/src/main/containers/MockupsPanel.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useContext } from 'react';
-// sample JSON to pass down as props. Will be able to remove as the project evolves.
-// import { largeData, smallData } from '../dummyData';
+import styled from 'styled-components';
 import StyledPanel from './StyledPanel.jsx';
 import { TestsContext } from '../testsContext';
 import Button from '../components/Button.jsx';
 import DataTree from '../components/DataTree.jsx';
+import Form from '../components/InlineForm.jsx';
+import Input from '../components/InlineInput.jsx';
 
 // will need to get data from the get request to pass to the formatted view
 const MockupsPanel = (props) => {
@@ -38,20 +39,52 @@ const MockupsPanel = (props) => {
     setTestsDiff(testsDiffClone);
   }
 
-  const testsDisplayList = [];
+  const Name = styled.h3`
+    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    color:  #999;
+  `;
+
+  const Label = styled.label`
+    color:  #999;
+    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-size: 0.9em;
+    text-transform: uppercase;
+  `;
+
+  const ModForm = styled(Form)`
+    flex-direction: column;
+    align-items: flex-start;
+  `;
+
+  const updateName = (name, index) => {
+    const testsCopy = [...tests];
+    testsCopy[index].name = name;
+    setTests(testsCopy);
+  };
+
+  const mockupsListDisplay = [];
   let i = 0;
-  tests.forEach((test) => {
-    testsDisplayList.push(
-      <div>
-        <h3 id={'title_' + i}>NAME</h3>
+  tests.forEach((test, index) => {
+    const { name } = test;
+    
+    const NameForm = <ModForm onSubmit={(e) => {
+        e.preventDefault();
+        updateName(e.target.children[0].value, index);
+      }}>
+      <Input name="name" placeholder={`Test #${i + 1}`} onBlur={e => updateName(e.target.value, index)}></Input>
+      <Label htmlFor="name">Name</Label>
+    </ModForm>;
+    mockupsListDisplay.push(
+      <article className='mockup' key={`mockup-${i}`}>
+        {name ? <Name onClick={() => updateName('', index)}>{name}</Name> : NameForm }
         <DataTree
           treeId={i}
-          key={`TestPanelDataTree ${i}`}
           data={test.payload}
+          name={''}
           options={dataTreeOptions}
           saveUpdatedTree={saveUpdatedTree}
         />
-      </div>,
+      </article>,
     );
     i += 1;
   });
@@ -59,7 +92,7 @@ const MockupsPanel = (props) => {
   function createNewTest() {
     const testsClone = [...tests];
     const testsDiffClone = [...testsDiff];
-    testsClone.push({ payload: data, status: '' });
+    testsClone.push({ payload: data, status: '', name: '' });
     testsDiffClone.push({});
 
     // the ID of the test will be the same as the position in the array
@@ -74,9 +107,9 @@ const MockupsPanel = (props) => {
           <div>
             {data && <h3>Server Response</h3>}
             {datacanvas}
-            {data && <Button enabled={true} onClick={createNewTest}> New Test </Button>}
+            {data && <Button enabled={true} onClick={createNewTest}>New Test</Button>}
           </div>
-          {testsDisplayList}
+          {mockupsListDisplay}
         </StyledPanel>
     );
   }

--- a/src/main/containers/MockupsPanel.jsx
+++ b/src/main/containers/MockupsPanel.jsx
@@ -7,6 +7,7 @@ import DataTree from '../components/DataTree.jsx';
 // import NameForm from '../components/NameForm.jsx';
 import Mockup from '../components/Mockup.jsx';
 
+
 // will need to get data from the get request to pass to the formatted view
 const MockupsPanel = (props) => {
   const {
@@ -16,6 +17,22 @@ const MockupsPanel = (props) => {
   const [tests, setTests] = useContext(TestsContext);
   const [testsListCounter, setTestsListCounter] = useState(0);
 
+  const saveUpdatedTree = (newData, arrayPosition, newValue, name, namespace) => {
+    // Update tests
+    const testsClone = [...tests];
+    testsClone[arrayPosition].payload = newData;
+    setTests(testsClone);
+
+    // Update tests differences/changes
+    const testsDiffClone = [...testsDiff];
+    // for deletion—find better syntax
+    if (!testsDiffClone[arrayPosition][namespace]) {
+      testsDiffClone[arrayPosition][namespace] = {};
+    }
+    testsDiffClone[arrayPosition][namespace][name] = newValue;
+    setTestsDiff(testsDiffClone);
+  };
+
   const mockupsListDisplay = [];
   let i = 0;
   tests.forEach((test, index) => {
@@ -23,12 +40,12 @@ const MockupsPanel = (props) => {
 
     mockupsListDisplay.push(
       // Creates a component for each test to display name and data
-      <Mockup key={index} test={test} index={index}/>,
+      <Mockup key={index} test={test} index={index} saveUpdatedTree={saveUpdatedTree} />,
     );
     i += 1;
   });
 
-  function createNewTest() {
+  const createNewTest = () => {
     const testsClone = [...tests];
     const testsDiffClone = [...testsDiff];
     testsClone.push({ payload: data, status: '', name: '' });
@@ -38,7 +55,7 @@ const MockupsPanel = (props) => {
     setTestsListCounter(testsListCounter + 1);
     setTests(testsClone);
     setTestsDiff(testsDiffClone);
-  }
+  };
 
   if (active) {
     return (

--- a/src/main/containers/MockupsPanel.jsx
+++ b/src/main/containers/MockupsPanel.jsx
@@ -4,8 +4,8 @@ import StyledPanel from './StyledPanel.jsx';
 import { TestsContext } from '../testsContext';
 import Button from '../components/Button.jsx';
 import DataTree from '../components/DataTree.jsx';
-import Form from '../components/InlineForm.jsx';
-import Input from '../components/InlineInput.jsx';
+// import NameForm from '../components/NameForm.jsx';
+import Mockup from '../components/Mockup.jsx';
 
 // will need to get data from the get request to pass to the formatted view
 const MockupsPanel = (props) => {
@@ -16,116 +16,14 @@ const MockupsPanel = (props) => {
   const [tests, setTests] = useContext(TestsContext);
   const [testsListCounter, setTestsListCounter] = useState(0);
 
-  const dataTreeOptions = {
-    onAdd: true,
-    onEdit: true,
-    onDelete: true,
-    enableClipboard: false,
-  };
-
-  function saveUpdatedTree(newData, arrayPosition, newValue, name, namespace) {
-    // Update tests
-    const testsClone = [...tests];
-    testsClone[arrayPosition].payload = newData;
-    setTests(testsClone);
-
-    // Update tests differences/changes
-    const testsDiffClone = [...testsDiff];
-    // for deletion-- find better syntax
-    if (!testsDiffClone[arrayPosition][namespace]) {
-      testsDiffClone[arrayPosition][namespace] = {};
-    }
-    testsDiffClone[arrayPosition][namespace][name] = newValue;
-    setTestsDiff(testsDiffClone);
-  }
-
-  const Name = styled.h3`
-    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    color: #292F32;
-  `;
-
-  const Label = styled.label`
-    color:  #BCC1C2;
-    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    font-size: 0.75em;
-  `;
-
-  const NameInput = styled(Input)`
-    padding: 0;
-    padding-bottom: 0.25em;
-  `;
-
-  const ModForm = styled(Form)`
-    flex-direction: column;
-    align-items: flex-start;
-    margin: 1em auto;
-  `;
-
-  const MockupHeader = styled.header`
-    display: flex;
-    align-items: flex-end;
-    h3 {
-      margin-bottom: 0;
-    }
-  `;
-
-  const EditButton = styled.button`
-    background: none;
-    border: none;
-    color: #4299EA;
-    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    letter-spacing: 0.05em;
-    margin: 0 auto 0.25em 0.825em;
-    text-transform: uppercase;
-    opacity: ${props => (props.visible ? 1 : 0)};
-    transition: all 0.2s ease-in-out;
-    &:hover {
-      cursor: pointer;
-      /* opacity: 1; */
-    }
-    &:active, &:focus {
-      color: #1F4E7A;
-      outline: 0;
-    }
-  `;
-
-  const updateName = (name, index) => {
-    const testsCopy = [...tests];
-    testsCopy[index].name = name;
-    setTests(testsCopy);
-  };
-
-  const [visibility, setVisibility] = useState(false);
-  // let visibility = false;
-
   const mockupsListDisplay = [];
   let i = 0;
   tests.forEach((test, index) => {
     const { name } = test;
-    
-    const NameForm = <ModForm onSubmit={(e) => {
-        e.preventDefault();
-        updateName(e.target.children[0].value, index);
-      }}>
-      <NameInput name="name" placeholder={`Test #${i + 1}`} onBlur={e => updateName(e.target.value, index)}></NameInput>
-      <Label htmlFor="name">Name</Label>
-    </ModForm>;
+
     mockupsListDisplay.push(
-      <article className='mockup' key={`mockup-${i}`}>
-        {name
-          ? <MockupHeader onMouseEnter={() => { setVisibility(true); }} onMouseLeave={() => setVisibility(false)}>
-              <Name>{name}</Name>
-              <EditButton onClick={() => updateName('', index)} visible={visibility}>Edit</EditButton>
-            </MockupHeader>
-          : NameForm }
-        <DataTree
-          treeId={i}
-          data={test.payload}
-          name={''}
-          options={dataTreeOptions}
-          saveUpdatedTree={saveUpdatedTree}
-        />
-      </article>,
+      // Creates a component for each test to display name and data
+      <Mockup key={index} test={test} index={index}/>,
     );
     i += 1;
   });

--- a/src/main/containers/MockupsPanel.jsx
+++ b/src/main/containers/MockupsPanel.jsx
@@ -7,7 +7,7 @@ import Button from '../components/Button.jsx';
 import DataTree from '../components/DataTree.jsx';
 
 // will need to get data from the get request to pass to the formatted view
-const TestPanel = (props) => {
+const MockupsPanel = (props) => {
   const {
     active, datacanvas, data, onClickFunction, setTestsDiff, testsDiff, setCursor,
   } = props;
@@ -91,4 +91,4 @@ const TestPanel = (props) => {
   );
 };
 
-export default TestPanel;
+export default MockupsPanel;

--- a/src/main/containers/MockupsPanel.jsx
+++ b/src/main/containers/MockupsPanel.jsx
@@ -86,7 +86,7 @@ const MockupsPanel = (props) => {
       onClick={onClickFunction}
       active={active}
       onMouseOver={() => setCursor('pointer')} >
-      <h1>Test</h1>
+      <h1>Mockups</h1>
     </StyledPanel>
   );
 };

--- a/src/main/containers/MockupsPanel.jsx
+++ b/src/main/containers/MockupsPanel.jsx
@@ -41,24 +41,32 @@ const MockupsPanel = (props) => {
 
   const Name = styled.h3`
     font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    color:  #999;
+    color: #292F32;
   `;
 
   const Label = styled.label`
-    color:  #999;
+    color:  #BCC1C2;
     font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    font-size: 0.9em;
-    text-transform: uppercase;
+    font-size: 0.75em;
+  `;
+
+  const NameInput = styled(Input)`
+    padding: 0;
+    padding-bottom: 0.25em;
   `;
 
   const ModForm = styled(Form)`
     flex-direction: column;
     align-items: flex-start;
+    margin: 1em auto;
   `;
 
   const MockupHeader = styled.header`
     display: flex;
-    align-items: center;
+    align-items: flex-end;
+    h3 {
+      margin-bottom: 0;
+    }
   `;
 
   const EditButton = styled.button`
@@ -67,13 +75,13 @@ const MockupsPanel = (props) => {
     color: #4299EA;
     font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     letter-spacing: 0.05em;
-    margin-left: 1em;
+    margin: 0 auto 0.25em 0.825em;
     text-transform: uppercase;
     opacity: ${props => (props.visible ? 1 : 0)};
-    transition: opacity 0.2s ease-in-out, color 0.2s ease-in-out;
+    transition: all 0.2s ease-in-out;
     &:hover {
       cursor: pointer;
-      opacity: 1;
+      /* opacity: 1; */
     }
     &:active, &:focus {
       color: #1F4E7A;
@@ -87,6 +95,9 @@ const MockupsPanel = (props) => {
     setTests(testsCopy);
   };
 
+  const [visibility, setVisibility] = useState(false);
+  // let visibility = false;
+
   const mockupsListDisplay = [];
   let i = 0;
   tests.forEach((test, index) => {
@@ -96,15 +107,15 @@ const MockupsPanel = (props) => {
         e.preventDefault();
         updateName(e.target.children[0].value, index);
       }}>
-      <Input name="name" placeholder={`Test #${i + 1}`} onBlur={e => updateName(e.target.value, index)}></Input>
+      <NameInput name="name" placeholder={`Test #${i + 1}`} onBlur={e => updateName(e.target.value, index)}></NameInput>
       <Label htmlFor="name">Name</Label>
     </ModForm>;
     mockupsListDisplay.push(
       <article className='mockup' key={`mockup-${i}`}>
-        {name 
-          ? <MockupHeader>
+        {name
+          ? <MockupHeader onMouseEnter={() => { setVisibility(true); }} onMouseLeave={() => setVisibility(false)}>
               <Name>{name}</Name>
-              <EditButton onClick={() => updateName('', index)}>Edit</EditButton>
+              <EditButton onClick={() => updateName('', index)} visible={visibility}>Edit</EditButton>
             </MockupHeader>
           : NameForm }
         <DataTree

--- a/src/main/containers/MockupsPanel.jsx
+++ b/src/main/containers/MockupsPanel.jsx
@@ -56,6 +56,31 @@ const MockupsPanel = (props) => {
     align-items: flex-start;
   `;
 
+  const MockupHeader = styled.header`
+    display: flex;
+    align-items: center;
+  `;
+
+  const EditButton = styled.button`
+    background: none;
+    border: none;
+    color: #4299EA;
+    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    letter-spacing: 0.05em;
+    margin-left: 1em;
+    text-transform: uppercase;
+    opacity: ${props => (props.visible ? 1 : 0)};
+    transition: opacity 0.2s ease-in-out, color 0.2s ease-in-out;
+    &:hover {
+      cursor: pointer;
+      opacity: 1;
+    }
+    &:active, &:focus {
+      color: #1F4E7A;
+      outline: 0;
+    }
+  `;
+
   const updateName = (name, index) => {
     const testsCopy = [...tests];
     testsCopy[index].name = name;
@@ -76,7 +101,12 @@ const MockupsPanel = (props) => {
     </ModForm>;
     mockupsListDisplay.push(
       <article className='mockup' key={`mockup-${i}`}>
-        {name ? <Name onClick={() => updateName('', index)}>{name}</Name> : NameForm }
+        {name 
+          ? <MockupHeader>
+              <Name>{name}</Name>
+              <EditButton onClick={() => updateName('', index)}>Edit</EditButton>
+            </MockupHeader>
+          : NameForm }
         <DataTree
           treeId={i}
           data={test.payload}

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import SourcePanel from './SourcePanel.jsx';
-import TestPanel from './TestPanel.jsx';
+import MockupsPanel from './MockupsPanel.jsx';
 import DestinationPanel from './DestinationPanel.jsx';
 import DataCanvas from './DataCanvas.jsx';
 // import { smallData, testsData } from '../dummyData';
@@ -43,7 +43,7 @@ const Panels = () => {
         active={(activePanel === 'source')}
         setCursor={setCursor} />
 
-      <TestPanel
+      <MockupsPanel
         onClickFunction={() => setActivePanel('test')}
         datacanvas={datacanvas}
         data={data}

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -10,14 +10,12 @@ const Panels = () => {
   const [activePanel, setActivePanel] = useState('source');
   const [data, setData] = useState(undefined);
   const [testsDiff, setTestsDiff] = useState([{}]);
-  const [cursor, setCursor] = useState('default');
   const [getFetchTimes, setGetFetchTimes] = useState([]);
   const [postFetchTimes, setPostFetchTimes] = useState([]);
 
   const PanelsWrapper = styled.section`
     display: flex;
     height: 80vh;
-    cursor: ${cursor};
   `;
 
   // Create DataCanvas component for component composition to
@@ -44,22 +42,19 @@ const Panels = () => {
         setData={setData}
         active={(activePanel === 'source')}
         fetchTimes={getFetchTimes}
-        setFetchTimes={setGetFetchTimes}
-        setCursor={setCursor} />
+        setFetchTimes={setGetFetchTimes} />
 
       <TestPanel
         onClickFunction={() => setActivePanel('test')}
         datacanvas={datacanvas}
         data={data}
         active={(activePanel === 'test')}
-        setCursor={setCursor}
         testsDiff={testsDiff}
         setTestsDiff={setTestsDiff} />
 
       <DestinationPanel
         onClickFunction={() => setActivePanel('dest')}
         active={(activePanel === 'dest')}
-        setCursor={setCursor}
         fetchTimes={postFetchTimes}
         setFetchTimes={setPostFetchTimes}
         testsDiff={testsDiff} />

--- a/src/main/containers/SourcePanel.jsx
+++ b/src/main/containers/SourcePanel.jsx
@@ -5,14 +5,14 @@ import PerformanceMetrics from '../components/PerformanceMetrics.jsx';
 
 const SourcePanel = (props) => {
   const {
-    setData, active, onClickFunction, setCursor, datacanvas, fetchTimes, setFetchTimes,
+    setData, active, onClickFunction, datacanvas, fetchTimes, setFetchTimes,
   } = props;
 
   const reducer = (accumulator, currentValue) => accumulator + currentValue;
 
   if (active) {
     return (
-      <StyledPanel active={active} onMouseOver={() => setCursor('default')}>
+      <StyledPanel active={active} style={{cursor: 'default'}}>
         <RequestBar SourceOrDest='source' setData={setData} setFetchTimes={setFetchTimes} />
         {datacanvas}
         { (fetchTimes.length > 0)
@@ -26,7 +26,7 @@ const SourcePanel = (props) => {
     <StyledPanel
       onClick={onClickFunction}
       active={active}
-      onMouseOver={() => setCursor('pointer')}
+      style={{cursor: 'pointer'}}
     >
       <h1>Source</h1>
     </StyledPanel>

--- a/src/main/containers/StyledPanel.jsx
+++ b/src/main/containers/StyledPanel.jsx
@@ -11,7 +11,7 @@ const StyledPanel = styled.section`
   padding: 0 2em 1em;
   position: relative;
   width: ${props => (props.active ? '80vw' : '10vw')};
-  h1, h3 {
+  h1 {
     color: #BCC1C2;
     font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     font-size: 1em;

--- a/src/main/containers/TestPanel.jsx
+++ b/src/main/containers/TestPanel.jsx
@@ -9,7 +9,7 @@ import DataTree from '../components/DataTree.jsx';
 // will need to get data from the get request to pass to the formatted view
 const TestPanel = (props) => {
   const {
-    active, datacanvas, data, onClickFunction, setTestsDiff, testsDiff, setCursor,
+    active, datacanvas, data, onClickFunction, setTestsDiff, testsDiff,
   } = props;
 
   const [tests, setTests] = useContext(TestsContext);
@@ -70,7 +70,7 @@ const TestPanel = (props) => {
 
   if (active) {
     return (
-        <StyledPanel active={active} onMouseOver={() => setCursor('default')}>
+        <StyledPanel active={active} style={{cursor: 'default'}}>
           <div>
             {data && <h3>Server Response</h3>}
             {datacanvas}
@@ -85,7 +85,7 @@ const TestPanel = (props) => {
     <StyledPanel
       onClick={onClickFunction}
       active={active}
-      onMouseOver={() => setCursor('pointer')} >
+      style={{cursor: 'pointer'}} >
       <h1>Test</h1>
     </StyledPanel>
   );


### PR DESCRIPTION
Alright folks, this is a pretty big PR so definitely let me know if you have any questions.

## Overview of what’s changed

- Sets initial collapsed value of data trees to “0” (more collapsed)
- Adds three new components:
  - `Mockup`, which encompasses everything needed for displaying new “tests”
  - `MockupName`, which displays the name of each mockup and an edit button
  - `NameForm` which provides a styled, inline name editing form for mockups
- Slight style changes to `ResponseComponent`—which now also displays each mockup’s name separately from its status
- Renames `TestPanel` to `MockupsPanel` for clarity
- Removes pretty much all mockup-related code from `MockupsPanel` (since it’s now handled with the `Mockup` component)

### Known issues
I designed the name for to be pretty minimal, so there’s no submit button. However, there are two expected behaviors (from a UX perspective) that I was _not_ able to implement for this PR:

#### Name should save on blur
Since there’s no submit button, it’s reasonable for users to expect their changes to save if they click out of the form. However, you **must** hit Enter for now—changes are only saved on form submissions.

#### Form input should initialize with name value
Editing a name causes the form to display a _placeholder_ equal to the current name. However, ideally this would be the actual input value, so a user can hit Edit, change their mind, and click out to retain the old name. As it is now, editing the name also essentially clears it. 
