### PR TITLE
Ability to write test assertions

### DIFF
--- a/src/main/components/AssertionsForm.jsx
+++ b/src/main/components/AssertionsForm.jsx
@@ -1,0 +1,120 @@
+import React, { useState, useContext } from 'react';
+import styled from 'styled-components';
+import { TestsContext } from '../testsContext';
+import Select from './InlineSelect.jsx';
+import InlineInput from './InlineInput.jsx';
+import Form from './InlineForm.jsx';
+import Button from './Button.jsx';
+
+// Styles
+const FormWrapper = styled.section`
+  background: #F0F3F4;
+  border-radius: 5px;
+  box-shadow: inset 0 0 2px 0 rgba(41, 47, 50, 0.25);
+  padding: 0.5em 1.5em;
+  h3 {
+    color: #555B5E;
+    font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-feature-settings: 'ss18';
+    font-size: 1em;
+    letter-spacing: 0.075em;
+    text-transform: uppercase;
+  }
+`;
+
+const Input = styled(InlineInput)`
+  background: none;
+  margin: 0 1em;
+  padding: 0 0 0.25em 0.25em;
+  text-align: center;
+`;
+
+const Fieldset = styled.fieldset`
+  border: none;
+`;
+
+const Label = styled.label`
+  color: #292F32;
+  font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+`;
+
+const AssertionsForm = (props) => {
+  const { index, setMode } = props;
+
+  // State
+  const [isRange, setIsRange] = useState(true);
+  const [minCode, setMinCode] = useState(200);
+  const [maxCode, setMaxCode] = useState(299);
+  const [exactCode, setExactCode] = useState(200);
+  const [tests, setTests] = useContext(TestsContext);
+
+  // Event handlers
+  const handleChange = (event) => {
+    const { value, name } = event.target;
+    switch (name) {
+      case 'rangeSelector':
+        if (value === 'range') setIsRange(true);
+        else setIsRange(false);
+        break;
+      case 'min-code':
+        setMinCode(Number.parseInt(value, 10));
+        break;
+      case 'max-code':
+        setMaxCode(Number.parseInt(value, 10));
+        break;
+      case 'exact-code':
+        setExactCode(Number.parseInt(value, 10));
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const testsCopy = [...tests];
+    const status = isRange ? [minCode, maxCode] : [exactCode];
+    testsCopy[index].expectedStatus = status;
+    setTests(testsCopy);
+    setMode('view');
+  };
+
+  return (
+    <FormWrapper>
+      <h3>Test Assertions</h3>
+      <Form onSubmit={handleSubmit}>
+        <Label htmlFor="status-code">Status Code</Label>
+        <Fieldset name="status-code">
+          <Select onChange={handleChange} name="rangeSelector">
+            <option value="range">Range</option>
+            <option value="exact">Exact Code</option>
+          </Select>
+          <Input
+            onChange={handleChange}
+            name={isRange ? 'min-code' : 'exact-code'}
+            defaultValue={isRange ? minCode : exactCode}
+            maxLength="3"
+            min="100"
+            max="599"
+            type="number"
+            bordered={false}>
+          </Input>
+          {isRange && <span>—</span>}
+          {isRange && <Input
+            onChange={handleChange}
+            name="max-code"
+            defaultValue={maxCode}
+            maxLength="3"
+            min={minCode + 1}
+            max="599"
+            type="number"
+            bordered={false}>
+          </Input>}
+        </Fieldset>
+        <Button enabled={true} type="submit" variation="positive">Save Changes</Button>
+      </Form>
+    </FormWrapper>
+  );
+};
+
+export default AssertionsForm;

--- a/src/main/components/InlineInput.jsx
+++ b/src/main/components/InlineInput.jsx
@@ -5,11 +5,11 @@ const InlineInput = styled.input`
   border-left: ${(props) => {
     if (props.bordered) return '1px solid #D8D8D8;';
     return 'none;';
-  }}
+  }};
   border-bottom: ${(props) => {
     if (!props.bordered) return '1px solid #D8D8D8;';
     return 'none;';
-  }}
+  }};
   color: #292F32;
   font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   font-size: 1em;
@@ -18,7 +18,7 @@ const InlineInput = styled.input`
   width: ${(props) => {
     if (!props.bordered) return 'fit-content;';
     return '100%;';
-  }}
+  }};
   &:focus {
     outline: none;
   }

--- a/src/main/components/Mockup.jsx
+++ b/src/main/components/Mockup.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import NameForm from './NameForm.jsx';
 import MockupName from './MockupName.jsx';
 import DataTree from './DataTree.jsx';
+import Button from './Button.jsx';
+import AssertionsForm from './AssertionsForm.jsx'
 
 const dataTreeOptions = {
   onAdd: true,
@@ -21,9 +23,9 @@ const Mockup = (props) => {
 
   return (
     <article className="mockup" key={`mockup-${index}`}>
-      {mode === 'view'
-        ? <MockupName name={name || `Test #${index + 1}`} setMode={setMode} />
-        : <NameForm name={name} index={index} setMode={setMode} setName={setName} />
+      {mode === 'editName'
+        ? <NameForm name={name} index={index} setMode={setMode} setName={setName} />
+        : <MockupName name={name || `Test #${index + 1}`} setMode={setMode} />
       }
       <DataTree
           treeId={index}
@@ -32,6 +34,10 @@ const Mockup = (props) => {
           options={dataTreeOptions}
           saveUpdatedTree={saveUpdatedTree}
         />
+      {mode === 'editAssertions'
+        ? <AssertionsForm setMode={setMode} index={index}/>
+        : <Button enabled={true} onClick={() => setMode('editAssertions')}>Edit Test Assertions</Button>
+      }
     </article>
   );
 };

--- a/src/main/components/MockupName.jsx
+++ b/src/main/components/MockupName.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 // Styles
@@ -41,7 +41,7 @@ const MockupName = (props) => {
   return (
     <Header onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
       <Name>{name}</Name>
-      <EditButton onClick={() => { setMode('edit'); }} hovered={hovered}>
+      <EditButton onClick={() => { setMode('editName'); }} hovered={hovered}>
       Edit
       </EditButton>
     </Header>

--- a/src/main/components/ResponseComponent.jsx
+++ b/src/main/components/ResponseComponent.jsx
@@ -45,16 +45,23 @@ const Header = styled.header`
 
 const ResponseComponent = (props) => {
   const {
-    status, payload, name, index
+    status, expectedStatus, payload, name, index,
   } = props;
 
   /* Download SF Symbols to view icons
   (https://developer.apple.com/design/human-interface-guidelines/sf-symbols/)
   (SVG icons to come) */
   let checkmark = '􀍡';
-  if (status >= 200 && status < 300) {
-    checkmark = '􀁣';
-  } else if (status >= 300) checkmark = '􀁡';
+  if (expectedStatus.length === 2) {
+    if (status >= expectedStatus[0] && status < expectedStatus[1]) checkmark = '􀁣';
+    else checkmark = '􀁡';
+  } else if (expectedStatus.length === 1) {
+    if (status === expectedStatus[0]) checkmark = '􀁣';
+    else checkmark = '􀁡';
+  } else {
+    if (status >= 200 && status < 300) checkmark = '􀁣';
+    else if (status >= 300) checkmark = '􀁡';
+  }
 
   return (
     <ResponseWrapper>

--- a/src/main/components/ResponseComponent.jsx
+++ b/src/main/components/ResponseComponent.jsx
@@ -16,9 +16,9 @@ const Icon = styled.span`
   font-family: 'SF Pro Text';
   margin-right: 0.625em;
   color: ${(props) => {
-    if (props.status >= 200 && props.status < 300) return '#77B86B;';
-    if (props.status >= 300) return '#E5544C;';
-    return '#292F32;';
+    if (props.didPass === 'pending') return '#555B5E';
+    if (props.didPass) return '#77B86B';
+    if (!props.didPass) return '#E5544C';
   }};
 `;
 
@@ -48,27 +48,61 @@ const ResponseComponent = (props) => {
     status, expectedStatus, payload, name, index,
   } = props;
 
-  /* Download SF Symbols to view icons
-  (https://developer.apple.com/design/human-interface-guidelines/sf-symbols/)
-  (SVG icons to come) */
-  let checkmark = '􀍡';
-  if (expectedStatus.length === 2) {
-    if (status >= expectedStatus[0] && status < expectedStatus[1]) checkmark = '􀁣';
-    else checkmark = '􀁡';
-  } else if (expectedStatus.length === 1) {
-    if (status === expectedStatus[0]) checkmark = '􀁣';
-    else checkmark = '􀁡';
-  } else {
-    if (status >= 200 && status < 300) checkmark = '􀁣';
-    else if (status >= 300) checkmark = '􀁡';
-  }
+  const didPass = () => {
+    if (!status) return 'pending';
+    if (!expectedStatus) {
+      return status >= 200 && status <= 299;
+    }
+    if (expectedStatus[1]) {
+      const [lower, upper] = expectedStatus;
+      return status >= lower && status <= upper;
+    }
+    return expectedStatus[0] === status;
+  };
+
+  const renderCheckmark = () => {
+    /* Download SF Symbols to view icons in app
+    (https://developer.apple.com/design/human-interface-guidelines/sf-symbols/)
+    (SVG icons to come) */
+    if (!status) return '􀍡';
+    return didPass() ? '􀁣' : '􀁡';
+  };
+
+  const renderExpectedStatus = () => {
+    if (!expectedStatus) {
+      return 'No assertion given';
+    }
+    if (expectedStatus.length === 2) {
+      const [lower, upper] = expectedStatus;
+      return `Expecting status code in the ${lower}–${upper} range`;
+    }
+    if (expectedStatus.length === 1) {
+      return `Expecting status code to be ${expectedStatus[0]}`;
+    }
+  };
+
+  const renderTestResult = () => {
+    if (!expectedStatus) {
+      return 'No assertion given';
+    }
+    if (expectedStatus[1]) {
+      const [lower, upper] = expectedStatus;
+      return didPass()
+        ? 'Passed'
+        : `Expected status code to fall between ${lower}–${upper}`;
+    }
+    return didPass()
+      ? 'Passed'
+      : `Expected status code to be ${expectedStatus[0]}`;
+  };
 
   return (
     <ResponseWrapper>
       <Header>
         <h3>{ name || `Test #${index + 1}` }</h3>
-        <Icon status={status}>{checkmark}</Icon>
+        <Icon didPass={didPass()}>{renderCheckmark()}</Icon>
         { status || 'Ready to send' }
+        <p>{ status ? renderTestResult() : renderExpectedStatus() }</p>
       </Header>
       <Code
         cols='50'

--- a/src/main/containers/DestinationPanel.jsx
+++ b/src/main/containers/DestinationPanel.jsx
@@ -19,6 +19,7 @@ const DestinationPanel = (props) => {
         payload={testsDiff[i]}
         name={tests[i].name}
         index={i}
+        expectedStatus={tests[i].expectedStatus}
         // fix later
         key={`DestPanelTest ${i}`}
       />,
@@ -45,7 +46,7 @@ const DestinationPanel = (props) => {
 
   // only returned if not active
   return (
-    <StyledPanel onClick={onClickFunction} active={active} style={{cursor: 'pointer'}}>
+    <StyledPanel onClick={onClickFunction} active={active} style={{ cursor: 'pointer' }}>
       <h1>Destination</h1>
     </StyledPanel>
   );


### PR DESCRIPTION
Adds ability to attach test assertions (for status code only) when creating mockups. 

## Overview

- Adds a button below each mockup that opens a “Test Assertions” form
- Users can choose to expect a range of status codes or a specific status code
- Assertions are saved to their corresponding test object under the `expectedStatus` key as an array:
  - Exact assertions will appear like `[200]`
  - Ranges will appear with the lower bound at index 0, and the upper bound at index 1: `[200, 299]`
- `ResponseComponent`s in the dest panel will display the assertion before tests are sent
- After tests are sent, each `ResponseComponent` will display whether the test passed or failed
- If no assertion is created, we’ll assume status codes 200–299 are “good” and any others are “bad”
- If an assertion fails, the icon will change to a red x and a brief explanation will appear

### Known issues
The main issue is that there’s very little validation for range assertions. While the input has to be a number, it’s theoretically possible to switch the bounds depending on which you enter first. 

Also, validation isn’t styled right now and looks ugly if it appears. 
