### PR TITLE
Touchup panel styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Interspect</title>
+  <style>
+    body {
+      margin: 0;
+    }
+  </style>
 </head>
 
 <body>

--- a/src/main/containers/Panels.jsx
+++ b/src/main/containers/Panels.jsx
@@ -20,7 +20,7 @@ const Panels = () => {
 
   const PanelsWrapper = styled.section`
     display: flex;
-    height: 80vh;
+    height: 100vh;
   `;
 
   // Create DataCanvas component for component composition to

--- a/src/main/containers/StyledPanel.jsx
+++ b/src/main/containers/StyledPanel.jsx
@@ -2,19 +2,19 @@ import React from 'react';
 import styled from 'styled-components';
 
 const StyledPanel = styled.section`
-  border: ${(props) => {
-    if (props.active) return 'none;';
-    return '1px solid #F0F3F4;';
-  }};
+  border-right: 1px solid #BCC1C2;
   max-height: 100vh;
   overflow-y: scroll;
-  padding: 0 2em 1em;
+  padding: ${(props) => {
+    if (props.active) return '3em 4em';
+    return '3em auto';
+  }};
   position: relative;
   width: ${props => (props.active ? '80vw' : '10vw')};
   h1 {
-    color: #BCC1C2;
+    color: #949C9E;
     font-family: 'Halyard Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    font-size: 1em;
+    font-size: 0.825em;
     font-weight: 400;
     text-align: center;
     text-transform: uppercase;

--- a/src/main/containers/StyledPanel.jsx
+++ b/src/main/containers/StyledPanel.jsx
@@ -5,8 +5,8 @@ const StyledPanel = styled.section`
   border: ${(props) => {
     if (props.active) return 'none;';
     return '1px solid #F0F3F4;';
-  }}
-  max-height: 80vh;
+  }};
+  max-height: 100vh;
   overflow-y: scroll;
   padding: 0 2em 1em;
   position: relative;


### PR DESCRIPTION
Panels should now:

- Extend to the full height of the app window
- Display a slightly darker border when collapsed
- Remove spaces between borders (@joepav can you please confirm?)